### PR TITLE
Do not install header files as public header

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -73,7 +73,7 @@ TEA_SETUP_COMPILER
 #-----------------------------------------------------------------------
 
 TEA_ADD_SOURCES([unix/syslog.c unix/parse_options.c unix/params.c unix/globals.c])
-TEA_ADD_HEADERS([unix/syslog.h unix/params.h])
+TEA_ADD_HEADERS([])
 TEA_ADD_INCLUDES([])
 TEA_ADD_LIBS([])
 TEA_ADD_CFLAGS([])


### PR DESCRIPTION
Adding `syslog.h` and `params.h` to `TEA_ADD_HEADER` marks them, as far as I can tell, as public. That triggers the autoconf logic to install those on a `make install` into the defined `includedir`. Which has the potential to override e.g. the `syslog.h` file from libc in case that's installed, and the install target is `/usr`, which is the common case for Linux distribution packaging.